### PR TITLE
Add conditional firewall disable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ win_update_category_names:
 win_update_reject_list: []
 win_update_accept_list: []
 win_update_server_selection: default
+win_update_disable_firewall: False
 failed_kb: []
 
 temp_directory: "{{ ansible_env.TEMP }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ win_update_category_names:
 win_update_reject_list: []
 win_update_accept_list: []
 win_update_server_selection: default
-win_update_disable_firewall: False
+win_update_disable_firewall: yes
 failed_kb: []
 
 temp_directory: "{{ ansible_env.TEMP }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,17 +4,17 @@
     msg: "win update server: {{ win_update_server }}"
   when: win_update_server is defined
 
-block:
-  - name: disable firewall for Domain, Public and Private profiles
-    win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
-    when: 
-      - "'Windows Server 2012' in ansible_distribution"
-  
-  - name: disable firewall for Domain, Public and Private profiles
-    win_shell: netsh advfirewall set  allprofiles state off
-    when: 
-      - "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
-when: windows_update_disable_firewall | bool
+- name: disable firewall for Domain, Public and Private profiles
+  win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+  when: 
+    - "'Windows Server 2012' in ansible_distribution"
+    - windows_update_disable_firewall | bool
+
+- name: disable firewall for Domain, Public and Private profiles
+  win_shell: netsh advfirewall set  allprofiles state off
+  when: 
+    - "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
+    - windows_update_disable_firewall | bool
 
 - name: get used space before update
   win_shell: Get-PSDrive C | Select-Object Used | ConvertTo-Json
@@ -48,14 +48,14 @@ when: windows_update_disable_firewall | bool
     - used_space_before_update.stdout is defined
     - used_space_after_update.stdout is defined
 
-block:
-  - name: enabled firewall for Domain, Public and Private profiles
-    win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
-    when: 
-      - "'Windows Server 2012' in ansible_distribution"
-  
-  - name: enable firewall for Domain, Public and Private profiles
-    win_shell: netsh advfirewall set  allprofiles state on
-    when: 
-      - "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
-when: windows_update_disable_firewall | bool
+- name: enabled firewall for Domain, Public and Private profiles
+  win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
+  when: 
+    - "'Windows Server 2012' in ansible_distribution"
+    - windows_update_disable_firewall | bool
+
+- name: enable firewall for Domain, Public and Private profiles
+  win_shell: netsh advfirewall set  allprofiles state on
+  when: 
+    - "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
+    - windows_update_disable_firewall | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,17 +4,17 @@
     msg: "win update server: {{ win_update_server }}"
   when: win_update_server is defined
 
-- name: disable firewall for Domain, Public and Private profiles
-  win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
-  when: 
-    - "'Windows Server 2012' in ansible_distribution"
-    - windows_update_disable_firewall | bool
-
-- name: disable firewall for Domain, Public and Private profiles
-  win_shell: netsh advfirewall set  allprofiles state off
-  when: 
-    - "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
-    - windows_update_disable_firewall | bool
+block:
+  - name: disable firewall for Domain, Public and Private profiles
+    win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+    when: 
+      - "'Windows Server 2012' in ansible_distribution"
+  
+  - name: disable firewall for Domain, Public and Private profiles
+    win_shell: netsh advfirewall set  allprofiles state off
+    when: 
+      - "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
+when: windows_update_disable_firewall | bool
 
 - name: get used space before update
   win_shell: Get-PSDrive C | Select-Object Used | ConvertTo-Json
@@ -48,14 +48,14 @@
     - used_space_before_update.stdout is defined
     - used_space_after_update.stdout is defined
 
-- name: enabled firewall for Domain, Public and Private profiles
-  win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
-  when: 
-    - "'Windows Server 2012' in ansible_distribution"
-    - windows_update_disable_firewall | bool
-
-- name: enable firewall for Domain, Public and Private profiles
-  win_shell: netsh advfirewall set  allprofiles state on
-  when: 
-    - "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
-    - windows_update_disable_firewall | bool
+block:
+  - name: enabled firewall for Domain, Public and Private profiles
+    win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
+    when: 
+      - "'Windows Server 2012' in ansible_distribution"
+  
+  - name: enable firewall for Domain, Public and Private profiles
+    win_shell: netsh advfirewall set  allprofiles state on
+    when: 
+      - "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
+when: windows_update_disable_firewall | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
     msg: "win update server: {{ win_update_server }}"
   when: win_update_server is defined
 
-block:
+- block:
   - name: disable firewall for Domain, Public and Private profiles
     win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
     when: 
@@ -48,7 +48,7 @@ when: windows_update_disable_firewall | bool
     - used_space_before_update.stdout is defined
     - used_space_after_update.stdout is defined
 
-block:
+- block:
   - name: enabled firewall for Domain, Public and Private profiles
     win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
     when: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
     msg: "win update server: {{ win_update_server }}"
   when: win_update_server is defined
 
-- block:
+block:
   - name: disable firewall for Domain, Public and Private profiles
     win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
     when: 
@@ -48,7 +48,7 @@ when: windows_update_disable_firewall | bool
     - used_space_before_update.stdout is defined
     - used_space_after_update.stdout is defined
 
-- block:
+block:
   - name: enabled firewall for Domain, Public and Private profiles
     win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
     when: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,15 @@
 
 - name: disable firewall for Domain, Public and Private profiles
   win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
-  when: "'Windows Server 2012' in ansible_distribution"
+  when: 
+    - "'Windows Server 2012' in ansible_distribution"
+    - windows_update_disable_firewall | bool
 
 - name: disable firewall for Domain, Public and Private profiles
   win_shell: netsh advfirewall set  allprofiles state off
-  when: "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
+  when: 
+    - "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
+    - windows_update_disable_firewall | bool
 
 - name: get used space before update
   win_shell: Get-PSDrive C | Select-Object Used | ConvertTo-Json
@@ -46,8 +50,12 @@
 
 - name: enabled firewall for Domain, Public and Private profiles
   win_shell: Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled True
-  when: "'Windows Server 2012' in ansible_distribution"
+  when: 
+    - "'Windows Server 2012' in ansible_distribution"
+    - windows_update_disable_firewall | bool
 
 - name: enable firewall for Domain, Public and Private profiles
   win_shell: netsh advfirewall set  allprofiles state on
-  when: "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
+  when: 
+    - "'Windows Server 2008' in ansible_distribution or 'Windows 7' in ansible_distribution"
+    - windows_update_disable_firewall | bool


### PR DESCRIPTION
Since it's not always desirable to disable the local Windows firewall when installing updates, I created a variable `win_update_disable_firewall`. By default this is set to "yes" so as not to break the existing work-flow, but this can be optionally overridden by setting `win_update_disable_firewall=no` in `vars/main.yml`, for example. I added blocks with a when condition that evaluates to a bool to determine whether or not firewall disabling tasks should run or be skipped. 